### PR TITLE
Fixes to fetching manifests

### DIFF
--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -164,8 +164,7 @@ impl S3Client {
             .rsplit_once('/')
             .map_or(&*fspec.key, |(_, after)| after);
         let url = self.inventory_base.with_key(&fspec.key);
-        let outfile =
-            self.make_dl_tempfile(&PathBuf::from(format!("data/{fname}.csv.gz")), &url)?;
+        let outfile = self.make_dl_tempfile(&PathBuf::from(format!("data/{fname}")), &url)?;
         self.download_object(&url, Some(&fspec.md5_checksum), &outfile)
             .await?;
         Ok(InventoryList::from_gzip_csv_file(url, outfile))

--- a/src/s3/streams.rs
+++ b/src/s3/streams.rs
@@ -72,7 +72,14 @@ impl Stream for ListManifestDates {
                 .common_prefixes
                 .unwrap_or_default()
                 .into_iter()
-                .filter_map(|CommonPrefix { prefix, .. }| prefix?.parse::<DateHM>().ok())
+                .filter_map(|CommonPrefix { prefix, .. }| {
+                    prefix?
+                        .strip_suffix('/')?
+                        .rsplit_once('/')
+                        .map(|(_, s)| s)?
+                        .parse::<DateHM>()
+                        .ok()
+                })
                 .collect::<VecDeque<_>>();
         }
     }


### PR DESCRIPTION
- Fix parsing of manifest dates from S3
- Remove redundant `.csv.gz` extension from downloaded inventory lists