### PR TITLE
v0.1.0-alpha.2 — Second alpha release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-In Development
---------------
+v0.1.0-alpha.2 (2025-01-06)
+---------------------------
 - After fully scanning an inventory list CSV file, delete it
 - `--version` now includes the Git commit hash
 - Log various process details when an error first occurs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "s3invsync"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3invsync"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha.2"
 edition = "2021"
 rust-version = "1.80"
 description = "AWS S3 Inventory-based backup tool with efficient incremental & versionId support"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 DANDI Developers
+Copyright (c) 2024-2025 DANDI Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- After fully scanning an inventory list CSV file, delete it
- `--version` now includes the Git commit hash
- Log various process details when an error first occurs
- Fix a stall when cleaning up after an error
- Add `--trace-progress` option
- Drastically reduce memory usage
- Reject keys with directory components with special meaning, not just keys with filenames with special meaning
- If the download path for an item already exists and points to a directory, delete the directory
- If any of the ancestors for an item's download path points to a file, delete the file
- Ignore keys in inventory lists that end with a slash and are zero-sized
- Fix locking of paths currently being processed
- Increase number of retries on failed S3 requests to 10 attempts
- Support loading AWS credentials from standard locations
- Treat Ctrl-C like an error, triggering graceful shutdown

Closes #81.