### PR TITLE
v0.2.0 — Ignoring more errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-In Development
---------------
+v0.2.0 (2025-02-26)
+-------------------
 - `--ok-errors` renamed to `--ignore-errors`; the old name remains usable but
   is deprecated.
 - Add `access-denied` and `invalid-object-state` items to `--ignore-errors`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,7 +1812,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "s3invsync"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3invsync"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.82"
 description = "AWS S3 Inventory-based backup tool with efficient incremental & versionId support"


### PR DESCRIPTION
- `--ok-errors` renamed to `--ignore-errors`; the old name remains usable but is deprecated.
- Add `access-denied` and `invalid-object-state` items to `--ignore-errors`