### PR TITLE
Increase Ubuntu version used to build binaries to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             suffix: ".exe"
             use-cross: false
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             os-name: linux
             architecture: x86_64
             suffix: ""


### PR DESCRIPTION
This is necessary for two reasons:

1. GitHub has deprecated the 20.04 runners and will stop supporting them on April 1 <https://github.com/actions/runner-images/issues/11101>.

2. We can no longer build on 20.04 because one of the dependencies compiles C code and the code for compiling that code now refuses to run on old GCC versions because they have a serious bug in memcmp.

CC @yarikoptic 